### PR TITLE
Remove 'version' field from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "vaadin-element-skeleton",
-  "version": "0.1.0",
   "homepage": "https://vaadin.com/elements",
   "authors": [
     "Vaadin Ltd"


### PR DESCRIPTION
It's deprecated: https://github.com/bower/spec/blob/master/json.md#version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/5)
<!-- Reviewable:end -->
