### PR TITLE
Move Chrome/Firefox tests from SauceLabs to Selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ addons:
 
 script:
   - gulp lint
-  - travis_retry xvfb-run -s '-screen 0 1024x768x24' wct
-  - travis_retry xvfb-run -s '-screen 0 1024x768x24' wct --dom=shadow
+  - travis_retry xvfb-run -s '-screen 0 1024x768x24' wct -l chrome -l firefox
+  - travis_retry xvfb-run -s '-screen 0 1024x768x24' wct -l chrome -l firefox --dom=shadow

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -3,25 +3,30 @@ var args = require('yargs').argv;
 module.exports = {
   extraScripts: args.dom === 'shadow' ? ['test/enable-shadow-dom.js'] : [],
   registerHooks: function(context) {
-    // run Saucelabs tests for
-    //  - internal PRs, except cases when branch contains 'quick/'
-    //  - daily builds, triggered by cron
-    if (
-      (process.env.TRAVIS_EVENT_TYPE === 'push' && process.env.TRAVIS_BRANCH.indexOf('quick/') === -1) ||
-      process.env.TRAVIS_EVENT_TYPE === 'cron'
-    ) {
-      context.options.plugins.sauce.browsers = [
-        // desktop
-        'Windows 10/chrome@54',
-        'Windows 10/firefox@50',
-        'Windows 10/microsoftedge@13',
-        'Windows 10/internet explorer@11',
-        'OS X 10.11/safari@9.0',
-        // mobile
-        'OS X 10.11/iphone@9.2',
-        'OS X 10.11/ipad@9.2',
-        'Linux/android@5.1'
-      ];
+    // The Good
+    var crossPlatforms = [
+      'Windows 10/chrome@55',
+      'Windows 10/firefox@50'
+    ];
+
+    // The Bad
+    var otherPlatforms = [
+      'OS X 10.11/iphone@9.3',
+      'OS X 10.11/ipad@9.3',
+      'Linux/android@5.1',
+      'Windows 10/microsoftedge@13',
+      'Windows 10/internet explorer@11',
+      'OS X 10.11/safari@10.0'
+    ];
+
+    // run SauceLabs tests for pushes, except cases when branch contains 'quick/'
+    if (process.env.TRAVIS_EVENT_TYPE === 'push' && process.env.TRAVIS_BRANCH.indexOf('quick/') === -1) {
+      // crossPlatforms are not tested here, but in Selenium WebDriver (see .travis.yml)
+      context.options.plugins.sauce.browsers = otherPlatforms;
+
+    // Run SauceLabs for daily builds, triggered by cron
+    } else if (process.env.TRAVIS_EVENT_TYPE === 'cron') {
+      context.options.plugins.sauce.browsers = crossPlatforms.concat(otherPlatforms);
     }
   }
 };


### PR DESCRIPTION
This change will reduce a build time, Chrome and Firefox instead of queuing in SauceLabs will be always tested locally in Travis VM with Selenium WebDriver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/11)
<!-- Reviewable:end -->