### PR TITLE
Remove travis_retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ addons:
 
 script:
   - gulp lint
-  - travis_retry xvfb-run -s '-screen 0 1024x768x24' wct -l chrome -l firefox
-  - travis_retry xvfb-run -s '-screen 0 1024x768x24' wct -l chrome -l firefox --dom=shadow
+  - xvfb-run -s '-screen 0 1024x768x24' wct -l chrome -l firefox
+  - xvfb-run -s '-screen 0 1024x768x24' wct -l chrome -l firefox --dom=shadow


### PR DESCRIPTION
If one single test in one single platform is failing then all tests will be performed three times, which will cause a big queue in SauceLabs.

`travis_retry` is hiding the dust under the carpet, we need to write **STABLE AND RELIABLE** tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/12)
<!-- Reviewable:end -->
