### PR TITLE
Separate `lint` and `perf:run` tasks, add travis_retry to `perf:run`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ install:
   - bower install
 
 before_script:
-  - xvfb-run -s '-screen 0 1024x768x24' gulp lint perf:run
+  - gulp lint
+  - travis_retry xvfb-run -s '-screen 0 1024x768x24' gulp perf:run
   - ([ "$TRAVIS_EVENT_TYPE" = "pull_request" ] || TRAVIS_BRANCH=quick/${TRAVIS_BUILD_ID} xvfb-run -s '-screen 0 1024x768x24' wct)
 
 script:


### PR DESCRIPTION
Sometimes (1 of 30 cases) `gulp perf:run` returns a low value without any reasons for that :(

Probably upgrading the lighthouse in future will help.

For now adding `gulp_retry` as a temporary solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/22)
<!-- Reviewable:end -->
