### PR TITLE
Fix stylelint to 7.10.1, 7.11.0 has an issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9655,10 +9655,6 @@
       "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
       "dev": true
     },
-    "test-fixture": {
-      "version": "github:polymerelements/test-fixture#26118ef0467501c33c02316e7016a2837baba10f",
-      "dev": true
-    },
     "test-value": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lighthouse": "~1.6.5",
     "polymer-cli": "^0.18.0",
     "polyserve": "^0.18.0",
-    "stylelint": "^7.7.0",
+    "stylelint": "7.10.1",
     "stylelint-config-vaadin": "latest",
     "web-component-tester": "^6.0.0",
     "yargs": "latest"


### PR DESCRIPTION
7.11.0 was released [4 days ago](https://github.com/stylelint/stylelint/releases) and it causes the "Cannot parse selector" issues for all selectors with the colon at the end, like 

```css
--vaadin-grid-body-cell: {
                       ^
}
```

The issue is already reported to the stylelint project: https://github.com/stylelint/stylelint/issues/2631

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/40)
<!-- Reviewable:end -->
