### PR TITLE
Don't ignore package.json, ignore package-lock.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "bower_components",
     "test",
     "gulpfile.js",
-    "package.json",
+    "package-lock.json",
     "wct.conf.js"
   ],
   "dependencies": {


### PR DESCRIPTION
The reason:

![](https://i.imgur.com/aqHCwa6.png)

Related to: https://github.com/vaadin/flow/issues/1951

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/47)
<!-- Reviewable:end -->
