### PR TITLE
Set nodejs version to 8.0 (npm to 5.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 dist: trusty
 language: node_js
-node_js: stable
+node_js: 8.0
 
 cache:
   directories:


### PR DESCRIPTION
There's something wrong with npm 5.3.0: https://travis-ci.org/vaadin/vaadin-element-skeleton/builds/255556408

Set node_js to 8.0 (and automatically npm to 5.0) to fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/50)
<!-- Reviewable:end -->
