### PR TITLE
Add 'API documentation ↗' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 # &lt;vaadin-element&gt;
 
 [Live Demo ↗](https://cdn.vaadin.com/vaadin-core-elements/master/vaadin-element/demo/)
+|
+[API documentation ↗](https://cdn.vaadin.com/vaadin-core-elements/master/vaadin-element/)
+
 
 [&lt;vaadin-element&gt;](https://vaadin.com/elements/-/element/vaadin-element) is a [Polymer 2](http://polymer-project.org) element providing &lt;element-functionality&gt;, part of the [Vaadin Core Elements](https://vaadin.com/elements).
 


### PR DESCRIPTION
This is the finding from today's UX tests. One of participants was struggling finding the link to the documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/53)
<!-- Reviewable:end -->
