### PR TITLE
Add webcomponentsjs to webcomponents.org demo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ```
 <custom-element-demo>
   <template>
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="vaadin-element.html">
     <next-code-block></next-code-block>
   </template>

--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "elements-demo-resources": "^2.0.0",
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
+    "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5"
   }
 }


### PR DESCRIPTION
Currently none of our components works in Firefox, e.g. https://www.webcomponents.org/element/vaadin/vaadin-date-picker

Let's fix that and support the last free browser :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/58)
<!-- Reviewable:end -->
