### PR TITLE
Add --no-save to npm i gemini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 
 script:
   - if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && "$TRAVIS_BRANCH" != quick/* ]]; then
-      npm i gemini@^4.0.0 gemini-sauce gemini-polyserve &&
+      npm i --no-save gemini@^4.0.0 gemini-sauce gemini-polyserve &&
       gemini test test/visual &&
       xvfb-run -s '-screen 0 1024x768x24' polymer test --env saucelabs;
     fi


### PR DESCRIPTION
From https://docs.npmjs.com/cli/install

> `--no-save`: Prevents saving to dependencies.

This change isn't necessary for CI, but it's helpful for developers, they would be able to copy-paste build steps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/64)
<!-- Reviewable:end -->
