### PR TITLE
Add test against iOS 11

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -4,7 +4,7 @@ module.exports = {
   registerHooks: function(context) {
     var saucelabsPlatforms = [
       'macOS 10.12/iphone@10.3',
-      'macOS 10.12/ipad@10.3',
+      'macOS 10.12/ipad@11.0',
       'Windows 10/microsoftedge@15',
       'Windows 10/internet explorer@11',
       'macOS 10.12/safari@11.0'


### PR DESCRIPTION
iOS11 is supported by SauceLabs now.

I think that it's overkill to test against iphone10+ipad10+iphone11+ipad11, and iphone10+ipad11 will be enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/78)
<!-- Reviewable:end -->
