### PR TITLE
Add test-suites file

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -6,17 +6,20 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>vaadin-element tests</title>
   <script src="../../web-component-tester/browser.js"></script>
+  <script src="test-suites.js"></script>
 </head>
 
 <body>
   <script>
     WCT._config.environmentScripts.push('webcomponentsjs/webcomponents-lite.js');
 
-    WCT.loadSuites([
-      'sample-test.html'
-    ].reduce(function(suites, suite) {
-      return suites.concat([suite, `${suite}?wc-shadydom=true`]);
-    }, []));
+    WCT.loadSuites(
+      VaadinElementSuites
+        .reduce(function(suites, suite) {
+          return suites.concat([suite, `${suite}?wc-shadydom=true`]);
+        }, []
+      )
+    );
   </script>
 </body>
 

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -1,0 +1,3 @@
+var VaadinElementSuites = [
+  'sample-test.html'
+];


### PR DESCRIPTION
Related https://github.com/vaadin/vaadin-overlay/issues/47

Rather than listing all combo-box, context-menu etc tests in overlay's tests (that are more than likely to change) like in https://github.com/vaadin/vaadin-overlay/pull/56, put all test files in an array at the element's test folder. This way we can import this variable in `overlay`'s tests and it will work despite element's test files have changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/85)
<!-- Reviewable:end -->
