### PR TITLE
Add sudo: true to Travis config for running chrome-sandbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 dist: trusty
 language: node_js
 node_js: 8.1


### PR DESCRIPTION
Current master is failing. As well as all other repos should fail.

Reason: https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524

Failing build: https://travis-ci.org/vaadin/vaadin-element-skeleton/jobs/326723962

![](https://i.imgur.com/Y7DpJdn.png)

`chrome-sandbox` need `sudo` in order to run :this-is-fine: 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/90)
<!-- Reviewable:end -->

  
  
  
  