### PR TITLE
Correct line endings of some files types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# The default behavior
+* text=auto
+
+*.html text
+*.js text
+*.json text
+*.md text
+
+.gitattributes text
+.gitignore text


### PR DESCRIPTION
Symptom: in windows with current `master`, running `npm install` will make `package.json` marked as changed, because it make the line ending *nix `LineFeed`

Please see https://github.com/vaadin/vaadin-combo-box/pull/578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/91)
<!-- Reviewable:end -->
