### PR TITLE
Switch back to using function closures

### DIFF
--- a/test/sample-test.html
+++ b/test/sample-test.html
@@ -26,6 +26,10 @@
         expect(element.localName).to.be.equal('vaadin-element');
       });
 
+      it('should not expose class name globally', function() {
+        expect(window.VaadinElement).not.to.be.ok;
+      });
+
     });
   </script>
 </body>

--- a/vaadin-element.html
+++ b/vaadin-element.html
@@ -22,7 +22,7 @@ This program is available under Apache License Version 2.0, available at https:/
   </template>
 
   <script>
-    {
+    (function() {
 
       /**
        * `<vaadin-element>` is a Polymer 2 element.
@@ -52,6 +52,6 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       window.Vaadin = window.Vaadin || {};
       Vaadin.VaadinElement = VaadinElement;
-    }
+    })();
   </script>
 </dom-module>


### PR DESCRIPTION
Connects to https://github.com/vaadin/vaadin-dropdown-menu/issues/98

So it appear the es6 block scope doesn't get transpiled properly. The variables defined in the block scopes end up in the global scope and cause collisions.

The added test in the PR will fail on IE without the fix because of this. This also causes the issue defined in https://github.com/vaadin/vaadin-dropdown-menu/issues/98

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/92)
<!-- Reviewable:end -->
