### PR TITLE
Run tests in headless Chrome and Firefox, use sudo: false in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: true
+sudo: false
 dist: trusty
 language: node_js
 node_js: 8.11
@@ -45,7 +45,7 @@ script:
           wct --env saucelabs;
         fi;
       else
-        xvfb-run -s '-screen 0 1024x768x24' wct;
+        wct;
       fi &&
       if [[ "$TRAVIS_EVENT_TYPE" = "cron" && "$TEST_SUITE" = "unit_tests" ]]; then
         wct --env saucelabs-cron;
@@ -57,9 +57,9 @@ script:
       magi p3-convert --out . --import-style=name &&
       yarn install --flat &&
       if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && "$TRAVIS_BRANCH" != quick/* ]]; then
-        wct --module-resolution=node --npm --env saucelabs;
+        wct --npm --env saucelabs;
       else
-        xvfb-run -s '-screen 0 1024x768x24' wct --module-resolution=node --npm;
+        wct --npm;
       fi;
     fi
 

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -4,8 +4,20 @@ var env = envIndex ? process.argv[envIndex] : undefined;
 module.exports = {
   testTimeout: 180 * 1000,
   verbose: false,
-  // MAGI REMOVE START
   plugins: {
+    local: {
+      browserOptions: {
+        chrome: [
+          'headless',
+          'disable-gpu',
+          'no-sandbox'
+        ],
+        firefox: [
+          '-headless'
+        ]
+      }
+    },
+    // MAGI REMOVE START
     istanbul: {
       dir: './coverage',
       reporters: ['text-summary', 'lcov'],
@@ -19,8 +31,8 @@ module.exports = {
         }
       }
     }
+    // MAGI REMOVE END
   },
-  // MAGI REMOVE END
 
   registerHooks: function(context) {
     const saucelabsPlatformsMobile = [


### PR DESCRIPTION
This, together with `no-sandbox` flag, also allows us to switch back to `sudo: false` and container-based environment in Travis, for possible speed improvements.

- [ ] vaadin-button - passing
- [ ] vaadin-checkbox - passing
- [ ] vaadin-combo-box - passing
- [ ] vaadin-context-menu - passing
- [ ] vaadin-control-state-mixin - passing
- [ ] vaadin-date-picker - passing
- [ ] vaadin-dialog - passing
- [ ] vaadin-dropdown-menu - passing
- [ ] vaadin-form-layout - passing
- [x] vaadin-grid - passing & merged
- [ ] vaadin-item - passing
- [ ] vaadin-list-box - passing
- [ ] vaadin-list-mixin - passing
- [ ] vaadin-notification - passing
- [ ] vaadin-ordered-layout - passing
- [ ] vaadin-overlay - passing
- [ ] vaadin-progress-bar - passing
- [ ] vaadin-radio-button - passing
- [ ] vaadin-split-layout - passing
- [ ] vaadin-tabs - passing
- [ ] vaadin-text-field - passing
- [ ] vaadin-themable-mixin - passing
- [ ] vaadin-upload - passing (with Firefox 61)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/93)
<!-- Reviewable:end -->
