### PR TITLE
Enable tests for safari9

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -7,7 +7,8 @@ module.exports = {
       'macOS 10.12/ipad@11.0',
       'Windows 10/microsoftedge@15',
       'Windows 10/internet explorer@11',
-      'macOS 10.12/safari@11.0'
+      'macOS 10.12/safari@11.0',
+      'macOS 9.3.2/iphone@9.3',
     ];
 
     var cronPlatforms = [


### PR DESCRIPTION
Now that all elements support Safari9 there should be automated tests for it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/100)
<!-- Reviewable:end -->
