### PR TITLE
remove unnecessary theme/lumo/new-element-name.html file

### DIFF
--- a/theme/lumo/new-element-name.html
+++ b/theme/lumo/new-element-name.html
@@ -1,1 +1,0 @@
-<link rel="import" href="../../src/vaadin-element.html">


### PR DESCRIPTION
All template files have the name 'vaadin-element.html', 'new-element-name.html' is not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/105)
<!-- Reviewable:end -->
