### PR TITLE
Update travis config to use stable Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 addons:
   firefox: latest
-  google-chrome: latest
+  chrome: stable
 
 install:
   - npm install


### PR DESCRIPTION
This enables us to run tests against Chrome 65, while the previous config seems to get stuck at 62.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/106)
<!-- Reviewable:end -->
