### PR TITLE
Remove fixed shadycss devDependency, revert #121

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,6 @@
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.0.1"
   },
   "devDependencies": {
-    "shadycss": "webcomponents/shadycss#~1.1.0",
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
     "webcomponentsjs": "^1.0.0",


### PR DESCRIPTION
https://github.com/Polymer/polymer/issues/5221 has been fixed, no need in fixing `shadycss` dependency anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/124)
<!-- Reviewable:end -->
