### PR TITLE
Move ipad to cronPlatforms

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -20,7 +20,6 @@ module.exports = {
   registerHooks: function(context) {
     var saucelabsPlatforms = [
       'macOS 10.12/iphone@10.3',
-      'macOS 10.12/ipad@11.0',
       'Windows 10/microsoftedge@15',
       'Windows 10/internet explorer@11',
       'macOS 10.12/safari@11.0',
@@ -29,6 +28,7 @@ module.exports = {
 
     var cronPlatforms = [
       'Android/chrome',
+      'macOS 10.12/ipad@11.0',
       'Windows 10/chrome@59',
       'Windows 10/firefox@54'
     ];


### PR DESCRIPTION
`saucelabsPlatforms.length` should be 5. 

Because OSS account concurrency limit is 5, when `saucelabsPlatforms.length` is greater than 5
the 6th testing session will be pending and eventually fail by timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/132)
<!-- Reviewable:end -->
