### PR TITLE
Travis: install wct-istanbul globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
   chrome: stable
 
 before_script:
-  - npm install -g bower polymer-cli@next
+  - npm install -g bower polymer-cli@next wct-istanbul
   - bower install
 
 env:


### PR DESCRIPTION
Currently, `p3-preview` branches will fail because 
- we're using `polymer-cli` instead of `wct` in them 
- `polymer-cli` is installed globally: https://github.com/vaadin/vaadin-element-skeleton/blob/p3-preview/.travis.yml#L15
- `wct-istabul` is installed locally: https://github.com/vaadin/vaadin-element-skeleton/blob/master/package.json#L43

This leads to: https://travis-ci.org/vaadin/vaadin-time-picker/jobs/391621782

> Could not find WCT plugin named "istanbul"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/135)
<!-- Reviewable:end -->
