### PR TITLE
Fixed end of line problem with gulp-html-extract plugin on Windows. A…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bower_components
 node_modules
 package-lock.json
+yarn.lock
 coverage

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,16 @@
 'use strict';
 
-var gulp = require('gulp');
-var eslint = require('gulp-eslint');
-var htmlExtract = require('gulp-html-extract');
-var stylelint = require('gulp-stylelint');
-var find = require('gulp-find');
-var replace = require('gulp-replace');
-var expect = require('gulp-expect-file');
-var grepContents = require('gulp-grep-contents');
-var clip = require('gulp-clip-empty-files');
-var git = require('gulp-git');
+const gulp = require('gulp');
+const eslint = require('gulp-eslint');
+const htmlExtract = require('gulp-html-extract');
+const lec = require('gulp-line-ending-corrector');
+const stylelint = require('gulp-stylelint');
+const find = require('gulp-find');
+const replace = require('gulp-replace');
+const expect = require('gulp-expect-file');
+const grepContents = require('gulp-grep-contents');
+const clip = require('gulp-clip-empty-files');
+const git = require('gulp-git');
 
 gulp.task('lint', ['lint:js', 'lint:html', 'lint:css']);
 
@@ -34,6 +35,7 @@ gulp.task('lint:html', function() {
       sel: 'script, code-example code',
       strip: true
     }))
+    .pipe(lec())
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError('fail'));

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-git": "^2.4.2",
     "gulp-grep-contents": "0.0.1",
     "gulp-html-extract": "^0.3.0",
+    "gulp-line-ending-corrector": "^1.0.2",
     "gulp-replace": "^0.6.1",
     "gulp-stylelint": "^7.0.0",
     "stylelint": "^9.0.0",


### PR DESCRIPTION
Fixed end of line problem with gulp-html-extract plugin on Windows.
Added yarn.lock to gitignore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/143)
<!-- Reviewable:end -->
