### PR TITLE
Add component with Material theme to main for modulizer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,8 +29,8 @@
     "polymer": "^2.0.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.1.0",
-    "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0",
-    "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0"
+    "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0-beta1",
+    "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0-beta1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,10 @@
     "Vaadin Ltd"
   ],
   "description": "vaadin-element",
-  "main": "vaadin-element.html",
+  "main": [
+    "vaadin-element.html",
+    "theme/material/vaadin-element.html"
+  ],
   "keywords": [
     "Vaadin",
     "vaadin-element",


### PR DESCRIPTION
We do not import components with Material theme anywhere now (e. g. in tests) so that some files in `theme/material` get incorrectly processed. By adding the entrypoints to the `main` field we make sure that polymer-modulizer will pick up these files.

Related to vaadin/vaadin-combo-box#690

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/153)
<!-- Reviewable:end -->
