### PR TITLE
Use @vaadin/vaadin-component-dev-dependencies for all devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,26 +22,6 @@
     "preversion": "gulp version:update"
   },
   "devDependencies": {
-    "bower": "latest",
-    "coveralls": "^3.0.1",
-    "eslint": "^5.0.0",
-    "eslint-config-vaadin": "latest",
-    "eslint-plugin-html": "^4.0.0",
-    "gulp": "latest",
-    "gulp-clip-empty-files": "^0.1.2",
-    "gulp-eslint": "^4.0.0",
-    "gulp-expect-file": "1.0.0",
-    "gulp-find": "0.0.10",
-    "gulp-git": "^2.4.2",
-    "gulp-grep-contents": "0.0.1",
-    "gulp-html-extract": "^0.3.0",
-    "gulp-line-ending-corrector": "^1.0.2",
-    "gulp-replace": "^0.6.1",
-    "gulp-stylelint": "^7.0.0",
-    "stylelint": "^9.0.0",
-    "stylelint-config-vaadin": "latest",
-    "wct-istanbul": "^0.14.3",
-    "web-component-tester": "^6.1.5",
-    "yargs": "^8.0.0"
+    "@vaadin/vaadin-component-dev-dependencies": "^1.0.0"
   }
 }


### PR DESCRIPTION
As discussed internally, `@vaadin/vaadin-component-dev-dependencies` will allow us to have the list of all `devDependencies` **in one place**, which will eliminate copy-pasting any changes into 20+ repositories.

https://github.com/vaadin/vaadin-component-dev-dependencies/blob/master/package.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/156)
<!-- Reviewable:end -->
