### PR TITLE
Use badgen for npm and bower versions badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://badgen.net/npm/v/@vaadin/vaadin-element-skeleton)](https://www.npmjs.com/package/@vaadin/vaadin-element-skeleton)
+[![Bower version](https://badgen.net/github/release/vaadin/vaadin-element-skeleton)](https://github.com/vaadin/vaadin-element-skeleton/releases)
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/vaadin/vaadin-element)
 [![Build Status](https://travis-ci.org/vaadin/vaadin-element.svg?branch=master)](https://travis-ci.org/vaadin/vaadin-element)
 [![Coverage Status](https://coveralls.io/repos/github/vaadin/vaadin-element/badge.svg?branch=master)](https://coveralls.io/github/vaadin/vaadin-element?branch=master)


### PR DESCRIPTION
Connected to https://github.com/vaadin/components-team-tasks/issues/338

https://badgen.net seems to be fast and reliable service for all kinds of badges.

For `vaadin-element-skeleton` badges are broken, as it's not published, here's the same change for `vaadin-button`: https://github.com/vaadin/vaadin-button/pull/104

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/158)
<!-- Reviewable:end -->
