### PR TITLE
Update vaadin-element-mixin to 2.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "polymer": "^2.0.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.1.0",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.0.0",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0-beta1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0-beta1"
   },
@@ -38,5 +38,8 @@
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.0.0"
+  },
+  "resolutions": {
+    "vaadin-element-mixin": "^2.0.0"
   }
 }


### PR DESCRIPTION
Note: we will have to keep the "resolutions" section at least until next major release, to force latest usage-statistics and dev-mode-detector to be picked up when used with bower (for npm, they would be the only stable option to use).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/161)
<!-- Reviewable:end -->
