### PR TITLE
Place webcomponents-lite.js before wct to run P3 tests

### DIFF
--- a/test/sample-test.html
+++ b/test/sample-test.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>vaadin-element tests</title>
-  <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../vaadin-element.html">
 </head>
 


### PR DESCRIPTION
This order should allow us to remove `test-fixture` imports and rely on WCT injecting it.
Apparently, previously there used to be timing issue because of the scripts order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/165)
<!-- Reviewable:end -->
