### PR TITLE
Use wildcard in the 'files' section of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
-    "vaadin-element.html",
+    "vaadin-*.js",
     "src",
     "theme"
   ],


### PR DESCRIPTION
First of all, there was a mistake made by me in the [previous PR](https://github.com/vaadin/vaadin-element-skeleton/pull/111) - it should be `.js`, not `.html`.

But, it would be handy in cases like `vaadin-combo-box`, `vaadin-date-picker`, etc. to have a wildcard:

```sh
vaadin-combo-box (master *) }> cat package.json
{
  ...
  "files": [
    "vaadin-*.js",
    "src",
    "theme"
  ]
  ...
}


vaadin-combo-box (master *) }> npm pack
npm notice
npm notice 📦  @vaadin/vaadin-combo-box@4.2.0-alpha1
npm notice === Tarball Contents ===
npm notice 583B   package.json
npm notice 10.8kB LICENSE
npm notice 5.5kB  README.md
npm notice 49B    vaadin-combo-box-light.js
npm notice 43B    vaadin-combo-box.js
npm notice 12.2kB src/vaadin-combo-box-dropdown-wrapper.js
npm notice 7.5kB  src/vaadin-combo-box-dropdown.js
npm notice 4.6kB  src/vaadin-combo-box-item.js
npm notice 4.4kB  src/vaadin-combo-box-light.js
npm notice 26.3kB src/vaadin-combo-box-mixin.js
npm notice 10.1kB src/vaadin-combo-box.js
npm notice 1.2kB  theme/lumo/vaadin-combo-box-dropdown-styles.js
npm notice 1.6kB  theme/lumo/vaadin-combo-box-item-styles.js
npm notice 138B   theme/lumo/vaadin-combo-box-light.js
npm notice 719B   theme/lumo/vaadin-combo-box-styles.js
npm notice 171B   theme/lumo/vaadin-combo-box.js
npm notice 785B   theme/material/vaadin-combo-box-dropdown-styles.js
npm notice 1.2kB  theme/material/vaadin-combo-box-item-styles.js
npm notice 138B   theme/material/vaadin-combo-box-light.js
npm notice 968B   theme/material/vaadin-combo-box-styles.js
npm notice 171B   theme/material/vaadin-combo-box.js
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/167)
<!-- Reviewable:end -->
