### PR TITLE
Fix version number test to allow alpha and beta

### DIFF
--- a/test/sample-test.html
+++ b/test/sample-test.html
@@ -32,7 +32,7 @@
       });
 
       it('should have a valid version number', function() {
-        expect(customElements.get('vaadin-element').version).to.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/);
+        expect(element.constructor.version).to.match(/^(\d+\.)?(\d+\.)?(\d+)(-(alpha|beta)\d+)?$/);
       });
 
     });


### PR DESCRIPTION
Same as vaadin/vaadin-rich-text-editor#48
also disallowing `1.0.*` version numbers from now on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/174)
<!-- Reviewable:end -->
