### PR TITLE
Revert "Place webcomponents-lite.js before wct to run P3 tests"

### DIFF
--- a/test/sample-test.html
+++ b/test/sample-test.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title>vaadin-element tests</title>
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-element.html">
 </head>
 


### PR DESCRIPTION
Reverts vaadin/vaadin-element-skeleton#165

Discussion: https://github.com/vaadin/vaadin-context-menu/pull/194#pullrequestreview-171006398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/179)
<!-- Reviewable:end -->
