### PR TITLE
[skip ci] Move Demo & API Docs to be more obvious.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@
 
 # &lt;vaadin-element&gt;
 
-[Live Demo ↗](https://vaadin.com/components/vaadin-element/html-examples)
-|
-[API documentation ↗](https://vaadin.com/components/vaadin-element/html-api)
-
-
 [&lt;vaadin-element&gt;](https://vaadin.com/components/vaadin-element) is a Web Component providing &lt;element-functionality&gt;, part of the [Vaadin components](https://vaadin.com/components).
 
 <!--
@@ -74,6 +69,13 @@ Once installed, import it in your application:
 ```js
 import '@vaadin/vaadin-element/vaadin-element.js';
 ```
+
+## Live Demo and API Documentation
+
+[Live Demo ↗](https://vaadin.com/components/vaadin-element/html-examples)
+|
+[API documentation ↗](https://vaadin.com/components/vaadin-element/html-api)
+
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import '@vaadin/vaadin-element/vaadin-element.js';
 [API documentation ↗](https://vaadin.com/components/vaadin-element/html-api)
 
 
-## Getting started
+## Theming
 
 Vaadin components use the Lumo theme by default.
 


### PR DESCRIPTION
The live demo and API documentation links get lost at the top of the document. The first expectations in *most* GitHub repositories is an explanation of what the repository is, not links somewhere else. 

These are important links (especially for newcomers to the project) and not easy to find when scanning the Readme. 

Moving them to their own section improves their findabilty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/186)
<!-- Reviewable:end -->
