### PR TITLE
[skip ci] Improved documentation for demos and tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,22 +92,42 @@ To use the Material theme, import the correspondent file from the `theme/materia
   `vaadin-element.html`
 
 
-## Running demos and tests in browser
+## Running demos and tests in a browser
+Ensure you have [npm](https://www.npmjs.com/) and [Bower](https://bower.io) installed.
 
-1. Fork the `vaadin-element` repository and clone it locally.
+Clone the `vaadin-select` repository.
+```bash
+$ git clone https://github.com/vaadin/vaadin-select.git
+```
 
-1. Make sure you have [npm](https://www.npmjs.com/) installed.
+Change into the `vaadin-select` directory.
+```bash
+$ cd vaadin-select
+```
 
-1. When in the `vaadin-element` directory, run `npm install` and then `bower install` to install dependencies.
+Install the dependencies.
+```bash
+$ npm install
+$ bower install
+```
 
-1. Make sure you have [polymer-cli](https://www.npmjs.com/package/polymer-cli) installed globally: `npm i -g polymer-cli`.
+Launch a webserver to serve the demo & tests.
+```bash
+$ polymer serve --port 3000
+```
 
-1. Run `npm start`, browser will automatically open the component API documentation.
+View the demos at :
 
-1. You can also open demo or in-browser tests by adding **demo** or **test** to the URL, for example:
+[http://127.0.0.1:3000/components/vaadin-select/demo](http://127.0.0.1:3000/components/vaadin-select/demo)
 
-  - http://127.0.0.1:8080/components/vaadin-element/demo
-  - http://127.0.0.1:8080/components/vaadin-element/test
+Run the tests :
+
+[http://127.0.0.1:3000/components/vaadin-select/test](http://127.0.0.1:3000/components/vaadin-select/test)
+
+View local version of API documentation  :
+
+[http://127.0.0.1:3000/](http://127.0.0.1:3000/)
+
 
 
 ## Running tests from the command line

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ To use the Material theme, import the correspondent file from the `theme/materia
 ## Running demos and tests in a browser
 Ensure you have [npm](https://www.npmjs.com/) and [Bower](https://bower.io) installed.
 
-Clone the `vaadin-select` repository.
+Clone the `vaadin-element` repository.
 ```bash
-$ git clone https://github.com/vaadin/vaadin-select.git
+$ git clone https://github.com/vaadin/vaadin-element.git
 ```
 
-Change into the `vaadin-select` directory.
+Change into the `vaadin-element` directory.
 ```bash
-$ cd vaadin-select
+$ cd vaadin-element
 ```
 
 Install the dependencies.
@@ -118,11 +118,11 @@ $ polymer serve --port 3000
 
 View the demos at :
 
-[http://127.0.0.1:3000/components/vaadin-select/demo](http://127.0.0.1:3000/components/vaadin-select/demo)
+[http://127.0.0.1:3000/components/vaadin-element/demo](http://127.0.0.1:3000/components/vaadin-element/demo)
 
 Run the tests :
 
-[http://127.0.0.1:3000/components/vaadin-select/test](http://127.0.0.1:3000/components/vaadin-select/test)
+[http://127.0.0.1:3000/components/vaadin-element/test](http://127.0.0.1:3000/components/vaadin-element/test)
 
 View local version of API documentation  :
 

--- a/README.md
+++ b/README.md
@@ -116,15 +116,15 @@ Launch a webserver to serve the demo & tests.
 $ npm start
 ```
 
-View the demos at :
+View the demos at:
 
 [http://127.0.0.1:3000/components/vaadin-element/demo](http://127.0.0.1:3000/components/vaadin-element/demo)
 
-Run the tests :
+Run the tests:
 
 [http://127.0.0.1:3000/components/vaadin-element/test](http://127.0.0.1:3000/components/vaadin-element/test)
 
-View local version of API documentation  :
+View local version of API documentation:
 
 [http://127.0.0.1:3000/](http://127.0.0.1:3000/)
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $ bower install
 
 Launch a webserver to serve the demo & tests.
 ```bash
-$ polymer serve --port 3000
+$ npm start
 ```
 
 View the demos at :


### PR DESCRIPTION
Assumes that https://github.com/vaadin/vaadin-element-skeleton/pull/177 is changed to include `polymer serve --port 3000`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-element-skeleton/190)
<!-- Reviewable:end -->
