### PR TITLE
test: update browser versions used in tests

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -33,17 +33,17 @@ module.exports = {
 
   registerHooks: function(context) {
     const saucelabsPlatformsMobile = [
-      'iOS Simulator/iphone@11.3',
-      'iOS Simulator/iphone@9.3'
+      'iOS Simulator/iphone@12.2',
+      'iOS Simulator/iphone@10.3'
     ];
 
     const saucelabsPlatformsMicrosoft = [
-      'Windows 10/microsoftedge@17',
+      'Windows 10/microsoftedge@18',
       'Windows 10/internet explorer@11'
     ];
 
     const saucelabsPlatformsDesktop = [
-      'macOS 10.13/safari@11.1'
+      'macOS 10.13/safari@latest'
     ];
 
     const saucelabsPlatforms = [
@@ -56,10 +56,10 @@ module.exports = {
       {
         deviceName: 'Android GoogleAPI Emulator',
         platformName: 'Android',
-        platformVersion: '7.1',
+        platformVersion: '8.1',
         browserName: 'chrome'
       },
-      'iOS Simulator/ipad@11.3',
+      'iOS Simulator/ipad@12.2',
       'iOS Simulator/iphone@10.3',
       'Windows 10/chrome@latest',
       'Windows 10/firefox@latest'


### PR DESCRIPTION
For some reason macOS 10.14 (Mojave) Safari 12 is not working in SauceLabs (always shows internal server error in browser when looking at the saved screen recording) so let's use "macOS 10.13/safari@latest" (Safari 12) instead which seems to be working.

Fixes https://github.com/vaadin/components-team-tasks/issues/450