### PR TITLE
chore(ci): pin Firefox version in travis to 66.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: latest
+  firefox: "66.0"
   chrome: stable
 
 jobs:
@@ -22,12 +22,12 @@ jobs:
     - if: type = pull_request
       env: POLYMER=2
       addons:
-        firefox: latest
+        firefox: "66.0"
         chrome: stable
     - if: type = pull_request
       env: POLYMER=3
       addons:
-        firefox: latest
+        firefox: "66.0"
         chrome: stable
     - if: type = cron
       env: TEST_SUITE=unit_tests POLYMER=2


### PR DESCRIPTION
The following error happens since update to 67:

```
Test run ended in failure: Error: [get("http://localhost:8081/components/[secure]-pro/generated-index.html?cli_browser_id=1")] Error response status: 13, UnknownError - An unknown server-side error occurred while processing the command. Selenium error: Failed to decode response from marionette
Build info: version: '3.12.0', revision: '7c6e0b3', time: '2018-05-08T15:15:08.936Z'
System info: host: 'travis-job-2bf06e8b-ba0e-4476-8925-b7152ea64d52', ip: '127.0.1.1', os.name: 'Linux', os.arch: 'amd64', os.version: '4.4.0-101-generic', java.version: '1.8.0_151'
Driver info: driver.version: unknown
```

Looks like a crash. Let's pin the version for now, as Polymer team did the same for lit-html.
